### PR TITLE
Release v 0 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "geo-nd"
-version = "0.1.7"
+version = "0.5.0"
 edition = "2021"
 readme = "README.md"
 authors = ["Gavin J Stark"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "geo-nd"
 version = "0.1.7"
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 authors = ["Gavin J Stark"]
 # exclude = ["/bors.toml", "/ci/*", "/.github/*"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ support architectural SIMD implementations within this crate.
 
 This crate is in alpha; it is used in a small number of applications,
 and the functionality is mature, but the API may undergo some changes
-in the near future (through Q3 2021) to ensure high performance OpenGL
+in the near future (through Q3 2023) to ensure high performance OpenGL
 and Vulkan operation while maintaining simplicity of operation for
 other applications.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,29 @@
+# Release 0.5.0 (2023-02-18)
+
+- Added multiply_dyn to matrix
+
+- Added serialize/deserialize of types
+
+- Added float 'pi' method
+
+- Added uniform distribution of vectors on a unit sphere
+
+- Added quaternion weighted averaging
+
+- Much addition of inline and must_use
+
+- Moved to Rust 2021 edition
+
+- Added 'into_array' method
+
+- Fixed SqMatrix mulitplication by Self to be matrix multiplication
+
+- Removed SqMatrix division by Self
+
+- Improved library documentation and examples
+
+- Added glsl module, which is not ready yet
+
 # Release 0.1.6 (2023-01-31)
 
 - Improved formatting of vectors

--- a/src/farray.rs
+++ b/src/farray.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::vector;
-use super::{Float, Vector};
+use super::{Float, Vector, Vector3};
 
 //a Macros
 //mi index_ops!
@@ -153,10 +153,16 @@ impl<F: Float, const D: usize> std::fmt::Display for FArray<F, D> {
     }
 }
 
+//ip Vector3<F> for FArray
+impl<F: Float> Vector3<F> for FArray<F, 3> {}
+
 //ip Vector<F,D> for FArray
 impl<F: Float, const D: usize> Vector<F, D> for FArray<F, D> {
     fn from_array(data: [F; D]) -> Self {
         Self { data }
+    }
+    fn into_array(self) -> [F; D] {
+        self.data
     }
     fn zero() -> Self {
         Self {
@@ -169,7 +175,7 @@ impl<F: Float, const D: usize> Vector<F, D> for FArray<F, D> {
     fn set_zero(&mut self) {
         vector::set_zero(&mut self.data)
     }
-    fn mix(&self, other: &Self, t: F) -> Self {
+    fn mix(self, other: &Self, t: F) -> Self {
         Self {
             data: vector::mix(&self.data, &other.data, t),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,24 @@ limitations under the License.
 @brief   Geometry library
  */
 
+/*a To do
+
+remove indexing from quaternions
+
+Add matrix trait which takes out most of the sqmatrix traits
+
+Document and get transform to work
+
+Fix rotate_x, rotate_y, rotate_z
+
+Make quaternion *not* be of V3 V4 but have them in the where of the functions as it is with of_rotation3
+
+quaternion distance functions?
+
+*/
 //a Documentation
 #![warn(missing_docs)]
 /*!
-#![warn(rustdoc::missing_doc_code_examples)]
 
 # Geometry library
 
@@ -42,9 +56,6 @@ clone, debug and display; some functions further require the
 [`Float`](Float) trait, which also requires operations such as sqrt,
 sin/cos, etc.
 
-The library does not expose any types: all of the operations it
-supports are provided through functions.
-
 ## Caveats
 
 The functions in the library use const generics, but as const generic
@@ -62,6 +73,11 @@ Additionally, the inference of a type for `V` is sometimes required to
 be forced, so there may be a small amount of turbofish notation such
 as `identity2::<f32>()`.
 
+# Function operation
+
+The functions for geometry manipulation are provided in the [vector],
+[mat] and [quat] modules.
+
 ## Basic operation
 
 ```
@@ -75,10 +91,231 @@ assert_eq!( vector::length_sq(&xy), (5.), "|x + 2*y|^2 = 5");
 assert_eq!( vector::length(&xy), (5.0f64).sqrt(), "|x + 2*y| = sqrt(5)");
 ```
 
-!*/
+# Provided traits
 
-//a Crates
-extern crate num_traits;
+The library provides traits for types that can be vectors, matrices, and quaternions.
+
+## Vector
+
+Types that provide [Vector] can be manipulated with negation, addition,
+subtraction, and can be scaled with multiplication and division by
+their 'float'; their components can be accessed through indexing
+(e.g. a[0]) immutably and mutably.
+
+ As non-traditional vector operations they can be piece-wise
+multiplied and divided also, which can be useful in graphcis
+applications; they can also be piece-wise added and subtracted from
+using their 'float'.
+
+They also support [Copy], [std::default::Default], [std::fmt::Debug], and [std::fmt::Display],
+[serde::Serialize], [serde::Deserialize].
+
+They provide AsRef for float arrays of length 4 and slices for fast import and export from memory structures.
+
+### Vector3
+
+Vector3 types are 3-element vectors which additionally provide a
+[Vector3::cross_product] method, which does not exist (in a simply
+well defined manner) for other vector sizes.
+
+## SqMatrix
+
+Types that provide [SqMatrix] are square matrices that can be
+manipulated with negation, addition, subtraction, and multiplicaton, and can be
+scaled with multiplication and division by their 'float'; their
+components can be accessed through indexing (e.g. a[0]) immutably and
+mutably. The index is a usize, in row-major order (i.e. [0] is row
+zero column zero, [1] is row 0 column 1, and [nr] is row 1 column 0
+for a matrixt that is 'nr' by 'nc' rows by columns.)
+
+ They can also be piece-wise added and subtracted from using their
+'float'.
+
+They also support [Copy], [std::default::Default], [std::fmt::Debug], and [std::fmt::Display],
+[serde::Serialize], [serde::Deserialize].
+
+They provide AsRef for float arrays of length 4 and slices for fast import and export from memory structures.
+
+
+### SqMatrix4
+
+Types that provide [SqMatrix4] are 4-by-4 matrices. Additional methods
+are provided for graphics operations, and so the matrices are treated
+as 3-by-3 transformation matrices with a translation vector and the
+last element the distance scaling.
+
+They provide [SqMatrix] and additionally support graphically-useful
+constructors 'perspective' and 'look_at', and support translation by
+vectors.
+
+## Quaternion
+
+Quaternions are a mathematical means for describing a 3 dimensional rotation around
+the origin.
+
+Types that provide [Quaternion] have associated 3-element and
+4-element vectors types that must provide the [Vector] trait.
+
+Types that provide [Quaternion] can be
+manipulated with negation, addition, subtraction, and multiplicaton, and can be
+scaled with multiplication and division by their 'float'.
+
+They also support [Copy], [std::default::Default], [std::fmt::Debug], and [std::fmt::Display],
+[serde::Serialize], [serde::Deserialize].
+
+They provide AsRef for float arrays of length 4 and slices for fast
+import and export from memory structures. Currently the mapping of the
+arrays is (i, j, k, r).
+
+### Constructors
+
+Types providing the [Quaternion] trait can be constructed from:
+
+* a unit quaternion (1.0 + 0*i + 0*j + 0*k)
+
+* (r,i,j,k) tuples
+
+* the conjugate of another quaternion, i.e. (r,-i,-j,-k)
+
+* a rotation around a [Vector<3>] axis by an angle (in radians)
+
+* a rotation around one of the axes applied to another quaternion
+
+* another quaternion applied to a rotation around one of the axes
+
+* from a square matrix that describes a pure rotation (no scaling)
+
+* that describes a rotation of a camera looking down the negative Z
+  axis with the Y axis as up, to one looking along a specified
+  direction with a (perpendicular) up direction
+
+* the rotation that provides the shortest great circle path for one
+  unit vector to another (the axis of the rotation is the
+  perpendicular to both)
+
+* the weighted average of a number of quaternions
+
+The trait provides many application methods for quaternions, perhaps
+the most important being [Quaternion::apply3] and
+[Quaternion::apply4], which allow the quaternion to be applied to a
+3-elemet or 4-element vector (the latter being common in graphics,
+where the fourth element is usually 1 for a point, and 0 for a vector
+translation).
+
+# Provided types
+
+The library provides types that simply wrap `f32` and `f64` arrays,
+providing imlpementations of the traits and hence supporting vectors, matrices and quaternions. This is perhaps the
+simplest way to use the library.
+
+## Vector types
+
+The [FArray] type is a wrapper around an N-element array of floats,
+and it supports the [Vector] trait.
+
+## SqMatrix types
+
+The [FArray2] type is a wrapper around an N-by-N-element array of floats,
+and it supports the [SqMatrix] trait.
+
+## Quaternion types
+
+The [QArray] type is a wrapper around an 4-element array of floats,
+and it supports the [Quaternion] trait.
+
+# Examples
+
+## Two dimensions
+
+```
+// Import the traits
+use geo_nd::{Vector, SqMatrix};
+
+// Aliases for the types
+pub type Point2D = geo_nd::FArray<f64, 2>;
+pub type Mat2x2 = geo_nd::FArray2<f64, 2, 4>;
+
+let x : Point2D = [1.0, 0.0].into();
+let y : Point2D = [0.0, 1.0].into();
+
+let c = 30.0_f64.to_radians().cos();
+let s = 30.0_f64.to_radians().sin();
+let rot30 : Mat2x2 = [c, -s, s, c].into();
+
+let rot60 = rot30 * rot30;
+
+// Rotating x anticlockwise by 30 and 60 should turn it into y
+let is_it_y = rot60.transform(&rot30.transform(&x));
+
+// Check that the distance between them is tiny
+assert!((y-is_it_y).length_sq() < 1.0E-8);
+
+assert!(y.distance(&is_it_y) < 1.0E-8);
+
+let rot90 = rot60 * rot30;
+let rot180 = rot90 * rot90;
+
+let xy = x + y;
+let is_it_zero = xy + rot180.transform(&xy);
+assert!(is_it_zero.length() < 1.0E-8);
+```
+
+## Three dimensions
+
+```
+// Import the traits
+use geo_nd::{Quaternion, SqMatrix, Vector};
+
+// Aliases for the types
+pub type Point3D = geo_nd::FArray<f64, 3>;
+pub type Mat3x3 = geo_nd::FArray2<f64, 3, 9>;
+pub type Point4D = geo_nd::FArray<f64, 4>;
+pub type Quat = geo_nd::QArray<f64, Point3D, Point4D>;
+
+let x : Point3D = [1., 0., 0.].into();
+let y : Point3D = [0., 1., 0.].into();
+let z : Point3D = [0., 0., 1.].into();
+
+// qx rotates around the X axis by 90 degrees
+// [X,0,0] is unchanged
+// [0,1,0] maps to [0,0,1]
+// [0,0,1] maps to [0,-1,0]
+let qx = Quat::unit().rotate_x(90.0_f64.to_radians());
+assert!(z.distance(&qx.apply3(&y)) < 1.0E-8);
+assert!(y.distance(&qx.apply3(&-z)) < 1.0E-8);
+assert!(x.distance(&qx.apply3(&x)) < 1.0E-8);
+
+// qy rotates around the Y axis by 90 degrees
+// [1,0,0] maps to [0,0,-1]
+// [0,Y,0] is unchanged
+// [0,0,1] maps to [1,0,0]
+let qy = Quat::unit().rotate_y(90.0_f64.to_radians());
+assert!(x.distance(&qy.apply3(&z)) < 1.0E-8);
+assert!(z.distance(&qy.apply3(&-x)) < 1.0E-8);
+assert!(y.distance(&qy.apply3(&y)) < 1.0E-8);
+
+// qx * qy applies qx to (qy applied to a vector)
+// Hence this chains the qx mapping onto the qy mapping
+// [1,0,0] -> [0,0,-1] -> [0,1,0]
+// [0,1,0] -> [0,1,0] -> [0,0,1]
+// [0,0,1] -> [1,0,0] -> [1,0,0]
+//
+// This is actually a 120 degree rotation around (1,1,1)
+// (qy * qx is a 120 degree rotation around (1,-1,1))
+let qxy = qx * qy;
+assert!(y.distance(&qxy.apply3(&x)) < 1.0E-8);
+assert!(z.distance(&qxy.apply3(&y)) < 1.0E-8);
+assert!(x.distance(&qxy.apply3(&z)) < 1.0E-8);
+
+let mut m = Mat3x3::default();
+qxy.set_rotation3(&mut m);
+// qxy will be [0,0,1,  1,0,0, 0,1,0]
+// give or take floating point errors
+assert!((m.transform(&x) - y).length() < 1.0E-8);
+assert!((m.transform(&y) - z).length() < 1.0E-8);
+assert!((m.transform(&z) - x).length() < 1.0E-8);
+```
+!*/
 
 //a Imports
 mod matrix_op;
@@ -87,19 +324,19 @@ mod quaternion_op;
 mod traits;
 mod vector_op;
 
+mod farray;
+mod farray2;
 mod fqarray;
-mod fslice;
-mod fslice2;
 mod qarray;
 
 //a Exports
+pub use farray::FArray;
+pub use farray2::FArray2;
 pub use fqarray::FQArrayTrans;
-pub use fslice::FArray;
-pub use fslice2::FArray2;
 pub use qarray::QArray;
 pub use traits::{
     Float, Geometry2D, Geometry3D, Num, Quaternion, SqMatrix, SqMatrix3, SqMatrix4, Transform,
-    Vector, Vector3D,
+    Vector, Vector3, Vector3D,
 };
 
 /// Vector functions module
@@ -145,7 +382,6 @@ pub mod simd {
     }
 }
 
-//a Implementations
 //a Vector3D and Geometry3D for f32/f64 using FArray/FArray2
 //ip Vector3D for f32
 impl Vector3D<f32> for f32 {
@@ -193,36 +429,37 @@ impl Geometry2D<f64> for f64 {
     type Mat2 = FArray2<f64, 2, 4>;
 }
 
-/*a Stuff
-// a Generic types as per GLSL
-/// GLSL 2-component vector of float
-pub type Vec2 = [f32;2];
-/// GLSL 3-component vector of float
-pub type Vec3 = [f32;3];
-/// GLSL 4-component vector of float
-pub type Vec4 = [f32;4];
-/// GLSL 2-component vector of double
-pub type DVec2 = [f64;2];
-/// GLSL 3-component vector of double
-pub type DVec3 = [f64;3];
-/// GLSL 4-component vector of double
-pub type DVec4 = [f64;4];
-/// GLSL 2-component vector of signed integer
-pub type IVec2 = [i32;2];
-/// GLSL 3-component vector of signed integer
-pub type IVec3 = [i32;3];
-/// GLSL 4-component vector of signed integer
-pub type IVec4 = [i32;4];
-/// GLSL 2x2 floating-point matrix
-pub type Mat2 = [f32;4];
-/// GLSL 3x3 floating-point matrix
-pub type Mat3 = [f32;9];
-/// GLSL 4x4 floating-point matrix
-pub type Mat4 = [f32;16];
-/// GLSL 2x2 double-precision floating-point matrix
-pub type DMat2 = [f64;4];
-/// GLSL 3x3double-precision floating-point matrix
-pub type DMat3 = [f64;9];
-/// GLSL 4x4 double-precision floating-point matrix
-pub type DMat4 = [f64;16];
- */
+//a GLSL-compatible things - bit of a place holder currently
+/// The [glsl] module is a place-holder for types that are compatible with GLSL
+pub mod glsl {
+    /// GLSL 2-component vector of float
+    pub type Vec2 = [f32; 2];
+    /// GLSL 3-component vector of float
+    pub type Vec3 = [f32; 3];
+    /// GLSL 4-component vector of float
+    pub type Vec4 = [f32; 4];
+    /// GLSL 2-component vector of double
+    pub type DVec2 = [f64; 2];
+    /// GLSL 3-component vector of double
+    pub type DVec3 = [f64; 3];
+    /// GLSL 4-component vector of double
+    pub type DVec4 = [f64; 4];
+    /// GLSL 2-component vector of signed integer
+    pub type IVec2 = [i32; 2];
+    /// GLSL 3-component vector of signed integer
+    pub type IVec3 = [i32; 3];
+    /// GLSL 4-component vector of signed integer
+    pub type IVec4 = [i32; 4];
+    /// GLSL 2x2 floating-point matrix
+    pub type Mat2 = [f32; 4];
+    /// GLSL 3x3 floating-point matrix
+    pub type Mat3 = [f32; 9];
+    /// GLSL 4x4 floating-point matrix
+    pub type Mat4 = [f32; 16];
+    /// GLSL 2x2 double-precision floating-point matrix
+    pub type DMat2 = [f64; 4];
+    /// GLSL 3x3double-precision floating-point matrix
+    pub type DMat3 = [f64; 9];
+    /// GLSL 4x4 double-precision floating-point matrix
+    pub type DMat4 = [f64; 16];
+}

--- a/src/matrixr_op.rs
+++ b/src/matrixr_op.rs
@@ -135,6 +135,8 @@ pub fn multiply<
 
 //mp multiply_dyn
 /// Multiply two matrices, dynamically sized
+///
+/// Until generic const expressions work cleanly this is a workaround
 pub fn multiply_dyn<V: Float>(
     r: usize,
     x: usize,

--- a/src/qarray.rs
+++ b/src/qarray.rs
@@ -301,41 +301,55 @@ where
     V3: Vector<F, 3>,
     V4: Vector<F, 4>,
 {
+    #[inline]
     fn from_array(data: [F; 4]) -> Self {
         Self::of_vector(V4::from_array(data))
     }
+    #[inline]
+    fn into_array(self) -> [F; 4] {
+        self.data.into_array()
+    }
+    #[inline]
     fn as_rijk(&self) -> (F, F, F, F) {
         quat::as_rijk(self.data.as_ref())
     }
+    #[inline]
     fn of_rijk(r: F, i: F, j: F, k: F) -> Self {
         Self::from_array(quat::of_rijk(r, i, j, k))
     }
+    #[inline]
     fn unit() -> Self {
         Self::of_rijk(F::one(), F::zero(), F::zero(), F::zero())
     }
+    #[inline]
     fn set_zero(&mut self) {
         self.data.set_zero();
     }
-    fn mix(&self, other: &Self, t: F) -> Self {
+    #[inline]
+    fn mix(self, other: &Self, t: F) -> Self {
         Self::of_vector(self.data.mix(&other.data, t))
     }
-    fn dot(&self, other: &Self) -> F {
+    #[inline]
+    fn dot(self, other: &Self) -> F {
         vector::dot(self.as_ref(), other.as_ref())
     }
     //fp of_rotation3
     /// Find the quaternion of a Matrix3 assuming it is purely a rotation
+    #[inline]
     fn of_rotation3<M>(rotation: &M) -> Self
     where
         M: SqMatrix<V3, F, 3, 9>,
     {
         Self::from_array(quat::of_rotation(rotation.as_ref()))
     }
+    #[inline]
     fn set_rotation3<M>(&self, matrix: &mut M)
     where
         M: SqMatrix<V3, F, 3, 9>,
     {
         quat::to_rotation3(self.as_ref(), matrix.as_mut())
     }
+    #[inline]
     fn set_rotation4<M>(&self, matrix: &mut M)
     where
         M: SqMatrix<V4, F, 4, 16>,

--- a/src/quaternion_op.rs
+++ b/src/quaternion_op.rs
@@ -34,12 +34,15 @@ use crate::{Float, Num};
 //a Constructors and destructors
 //fp new
 /// Create a new quaternion
+#[must_use]
+#[inline]
 pub fn new<V: Num>() -> [V; 4] {
     [V::zero(), V::zero(), V::zero(), V::one()]
 }
 
 //fp as_rijk
 /// Return the breakdown of a quaternion
+#[must_use]
 #[inline]
 pub fn as_rijk<V: Num>(v: &[V; 4]) -> (V, V, V, V) {
     (v[3], v[0], v[1], v[2])
@@ -47,6 +50,7 @@ pub fn as_rijk<V: Num>(v: &[V; 4]) -> (V, V, V, V) {
 
 //fp of_rijk
 /// Create a quaternion from its components
+#[must_use]
 #[inline]
 pub fn of_rijk<V: Num>(r: V, i: V, j: V, k: V) -> [V; 4] {
     [i, j, k, r]
@@ -54,6 +58,7 @@ pub fn of_rijk<V: Num>(r: V, i: V, j: V, k: V) -> [V; 4] {
 
 //fp identity
 /// Create an identity quaternion
+#[must_use]
 #[inline]
 pub fn identity<V: Num>() -> [V; 4] {
     [V::zero(), V::zero(), V::zero(), V::one()]
@@ -61,6 +66,8 @@ pub fn identity<V: Num>() -> [V; 4] {
 
 //fp of_axis_angle
 /// Find the quaternion for a rotation of an angle around an axis
+#[must_use]
+#[inline]
 pub fn of_axis_angle<V: Float>(axis: &[V; 3], angle: V) -> [V; 4] {
     let (s, c) = V::sin_cos(angle / V::from(2).unwrap());
     let l = vector::length(axis);
@@ -78,6 +85,8 @@ pub fn of_axis_angle<V: Float>(axis: &[V; 3], angle: V) -> [V; 4] {
 
 //fp as_axis_angle
 /// Return the axis of the rotation and the angle from the quaternion
+#[must_use]
+#[inline]
 pub fn as_axis_angle<V: Float>(q: &[V; 4]) -> ([V; 3], V) {
     let (r, i, j, k) = as_rijk(q);
     let i2 = i * i;
@@ -156,6 +165,7 @@ pub fn to_rotation4<V: Float>(q: &[V; 4], m: &mut [V; 16]) {
 
 //fp of_rotation
 /// Find the quaternion of a Matrix3 assuming it is purely a rotation
+#[must_use]
 pub fn of_rotation<V: Float>(m: &[V; 9]) -> [V; 4] {
     fn safe_sqrt<V: Float>(x: V) -> V {
         if x < V::zero() {
@@ -187,6 +197,7 @@ pub fn of_rotation<V: Float>(m: &[V; 9]) -> [V; 4] {
 
 //fp look_at
 /// Create quaternion for a rotation that maps unit dirn to (0,0,-1) and unit up to (0,1,0)
+#[must_use]
 pub fn look_at<V: Float>(dirn: &[V; 3], up: &[V; 3]) -> [V; 4] {
     let m = matrix::look_at3(dirn, up);
     of_rotation(&m)
@@ -195,6 +206,8 @@ pub fn look_at<V: Float>(dirn: &[V; 3], up: &[V; 3]) -> [V; 4] {
 //a Mapping functions
 //cp invert
 /// Get the quaternion inverse
+#[must_use]
+#[inline]
 pub fn invert<V: Float>(a: &[V; 4]) -> [V; 4] {
     let l = vector::length_sq(a);
     let r_l = {
@@ -209,18 +222,28 @@ pub fn invert<V: Float>(a: &[V; 4]) -> [V; 4] {
 
 //cp conjugate
 /// Find the conjugate of a quaternion
+#[must_use]
+#[inline]
 pub fn conjugate<V: Num>(a: &[V; 4]) -> [V; 4] {
     [-a[0], -a[1], -a[2], a[3]]
 }
 
 //cp normalize
 /// Find the conjugate of a quaternion
+#[must_use]
+#[inline]
 pub fn normalize<V: Float>(a: [V; 4]) -> [V; 4] {
     vector::normalize(a)
 }
 
 //cp rotate_x
-/// Find a rotation about the X-axis
+/// Apply a rotation about the X-axis to this quaternion
+///
+/// Rotation about the X axis is c+i*s
+///
+/// (c+i*s) * a[] = c*a - s*a[i] + i.s*a[r] - j.s*a[k] + k.s*a[j]
+#[must_use]
+#[inline]
 pub fn rotate_x<V: Float>(a: &[V; 4], angle: V) -> [V; 4] {
     let (s, c) = V::sin_cos(angle / V::from(2).unwrap());
     let i = a[0] * c + a[3] * s;
@@ -231,7 +254,9 @@ pub fn rotate_x<V: Float>(a: &[V; 4], angle: V) -> [V; 4] {
 }
 
 //cp rotate_y
-/// Find a rotation about the Y-axis
+/// Apply a rotation about the Y-axis to this quaternion
+#[must_use]
+#[inline]
 pub fn rotate_y<V: Float>(a: &[V; 4], angle: V) -> [V; 4] {
     let (s, c) = V::sin_cos(angle / V::from(2).unwrap());
     let i = a[0] * c - a[2] * s;
@@ -242,7 +267,9 @@ pub fn rotate_y<V: Float>(a: &[V; 4], angle: V) -> [V; 4] {
 }
 
 //cp rotate_z
-/// Find a rotation about the Z-axis
+/// Apply a rotation about the Z-axis to this quaternion
+#[must_use]
+#[inline]
 pub fn rotate_z<V: Float>(a: &[V; 4], angle: V) -> [V; 4] {
     let (s, c) = V::sin_cos(angle / V::from(2).unwrap());
     let i = a[0] * c + a[1] * s;
@@ -254,6 +281,7 @@ pub fn rotate_z<V: Float>(a: &[V; 4], angle: V) -> [V; 4] {
 
 //cp multiply
 /// Multiply two quaternions together
+#[must_use]
 #[inline]
 pub fn multiply<V: Num>(a: &[V; 4], b: &[V; 4]) -> [V; 4] {
     let i = a[0] * b[3] + a[3] * b[0] + a[1] * b[2] - a[2] * b[1];
@@ -265,6 +293,8 @@ pub fn multiply<V: Num>(a: &[V; 4], b: &[V; 4]) -> [V; 4] {
 
 //cp divide
 /// Multiply one quaternion by the conjugate of the other / len2 of other
+#[must_use]
+#[inline]
 pub fn divide<V: Float>(a: &[V; 4], b: &[V; 4]) -> [V; 4] {
     let l2 = vector::length_sq(b);
     if l2 < V::epsilon() {
@@ -280,6 +310,8 @@ pub fn divide<V: Float>(a: &[V; 4], b: &[V; 4]) -> [V; 4] {
 
 //fp nlerp
 /// A simple normalized LERP from one quaterion to another (not spherical)
+#[must_use]
+#[inline]
 pub fn nlerp<V: Float>(t: V, in0: &[V; 4], in1: &[V; 4]) -> [V; 4] {
     normalize(vector::mix(in0, in1, t))
 }
@@ -287,6 +319,11 @@ pub fn nlerp<V: Float>(t: V, in0: &[V; 4], in1: &[V; 4]) -> [V; 4] {
 //a Operational functions
 //fp distance_sq
 /// Get a measure of the 'distance' between two quaternions
+///
+/// This is calculated as |a' * b|, where || is the l
+///
+/// Should this instead be 1 - <a.b>^2 where a.b is the inner product?
+#[inline]
 pub fn distance_sq<V: Float>(a: &[V; 4], b: &[V; 4]) -> V {
     let qi = invert(a);
     let mut qn = multiply(&qi, b);
@@ -300,20 +337,14 @@ pub fn distance_sq<V: Float>(a: &[V; 4], b: &[V; 4]) -> V {
 
 //fp distance
 /// Get a measure of the 'distance' between two quaternions
+#[inline]
 pub fn distance<V: Float>(a: &[V; 4], b: &[V; 4]) -> V {
     distance_sq(a, b).sqrt()
 }
 
-//fp get_axis_angle
-/// Get the axis of a quaternion, and the angle of rotation it corresponds to
-pub fn get_axis_angle<V: Float>(q: &[V; 4]) -> ([V; 3], V) {
-    let angle = V::from(2).unwrap() * V::acos(q[3]);
-    let axis = vector::normalize([q[0], q[1], q[2]]);
-    (axis, angle)
-}
-
 //fp to_euler
 /// Convert the quaternion to a bank, heading, altitude tuple - applied in that order
+#[must_use]
 pub fn to_euler<V: Float>(q: &[V; 4]) -> (V, V, V) {
     let i = q[0];
     let j = q[1];
@@ -344,6 +375,7 @@ pub fn to_euler<V: Float>(q: &[V; 4]) -> (V, V, V) {
 
 //fp apply3
 /// Apply the quaternion to a vector3
+#[must_use]
 pub fn apply3<V: Float>(q: &[V; 4], v: &[V; 3]) -> [V; 3] {
     let (r, i, j, k) = as_rijk(q);
     let two = V::frac(2, 1);
@@ -361,6 +393,7 @@ pub fn apply3<V: Float>(q: &[V; 4], v: &[V; 3]) -> [V; 3] {
 
 //fp apply4
 /// Apply the quaternion to a vector3
+#[must_use]
 pub fn apply4<V: Float>(q: &[V; 4], v: &[V; 4]) -> [V; 4] {
     let (r, i, j, k) = as_rijk(q);
     let two = V::frac(2, 1);
@@ -376,14 +409,15 @@ pub fn apply4<V: Float>(q: &[V; 4], v: &[V; 4]) -> [V; 4] {
     [x, y, z, v[3]]
 }
 
-//fp weighted_average
+//fp weighted_average_pair
 /// Calculate the weighted average of two unit quaternions
 ///
 /// w_a + w_b must be 1.
 ///
 /// See http://www.acsu.buffalo.edu/~johnc/ave_quat07.pdf
 /// Averaging Quaternions by F. Landis Markley
-pub fn weighted_average<V: Float>(qa: &[V; 4], w_a: V, qb: &[V; 4], w_b: V) -> [V; 4] {
+#[must_use]
+pub fn weighted_average_pair<V: Float>(qa: &[V; 4], w_a: V, qb: &[V; 4], w_b: V) -> [V; 4] {
     let (ra, ia, ja, ka) = as_rijk(qa);
     let (rb, ib, jb, kb) = as_rijk(qb);
     let four = V::frac(4, 1);
@@ -406,29 +440,55 @@ pub fn weighted_average<V: Float>(qa: &[V; 4], w_a: V, qb: &[V; 4], w_b: V) -> [
 //fp weighted_average_many
 /// Calculate the weighted average of many unit quaternions
 ///
-/// weights need not add up to 1
+/// weights need not add up to 1, but must be nonzero
 ///
 /// This is an approximation compared to the Landis Markley paper
-pub fn weighted_average_many<V: Float>(values: &[(V, [V; 4])]) -> [V; 4] {
-    assert!(!values.is_empty());
-    let num_values = values.len();
-    if num_values == 1 {
-        values[0].1
-    } else {
-        let mut next_values = Vec::new();
-        for i in 0..(num_values + 1) / 2 {
-            if 2 * i + 1 == num_values {
-                let (w, v) = values[2 * i];
-                next_values.push((w, v));
+#[must_use]
+pub fn weighted_average_many<I: Iterator<Item = (V, [V; 4])>, V: Float>(
+    mut values_iter: I,
+) -> [V; 4] {
+    let (mut weight_ih, mut value_ih) = values_iter
+        .next()
+        .expect("weighted_average_many MUST be invoked with at least one quaternion");
+    let mut next_values = Vec::new();
+    loop {
+        if let Some((second_weight, second_value)) = values_iter.next() {
+            let w12 = weight_ih + second_weight;
+            let av = weighted_average_pair(
+                &value_ih,
+                weight_ih / w12,
+                &second_value,
+                second_weight / w12,
+            );
+            next_values.push((w12, av));
+        } else {
+            // No value to pair with in-hand; if there are none on the
+            // list then the iterator only had one entry, so return that
+            if next_values.is_empty() {
+                return value_ih;
             } else {
-                let (w1, v1) = values[2 * i];
-                let (w2, v2) = values[2 * i + 1];
-                let w12 = w1 + w2;
-                let av = weighted_average(&v1, w1 / w12, &v2, w2 / w12);
-                next_values.push((w12, av));
+                // Iterator must have returned at least 2n+1 (n>=1) entries
+                //
+                // next_values must be 'n' long already, make it n+1 and break
+                next_values.push((weight_ih, value_ih));
+                break;
             }
         }
-        weighted_average_many(&next_values)
+        // In-hand values have been consumed, fill them up or finish
+        if let Some((w, v)) = values_iter.next() {
+            // Iterator must have returned at least 3 values now
+            weight_ih = w;
+            value_ih = v;
+        } else {
+            // Iterator has returned 2n values with n>=1
+            break;
+        }
+    }
+    if next_values.len() == 1 {
+        next_values[0].1
+    } else {
+        let values_iter = next_values.into_iter();
+        weighted_average_many(values_iter)
     }
 }
 
@@ -436,7 +496,8 @@ pub fn weighted_average_many<V: Float>(values: &[(V, [V; 4])]) -> [V; 4] {
 /// Get a quaternion that is a rotation of one vector to another
 ///
 /// The vectors must be unit vectors
-pub fn get_rotation_of_vec_to_vec<V: Float>(a: &[V; 3], b: &[V; 3]) -> [V; 4] {
+#[must_use]
+pub fn rotation_of_vec_to_vec<V: Float>(a: &[V; 3], b: &[V; 3]) -> [V; 4] {
     let obtuse = vector::dot(a, b) < V::zero();
     let cp = vector::cross_product3(a, b);
     let sa = vector::length(&cp);

--- a/tests/quaternion.rs
+++ b/tests/quaternion.rs
@@ -50,14 +50,14 @@ fn test() {
     let y: FArray<f32, 3> = [0., 1., 0.].into();
     let z: FArray<f32, 3> = [0., 0., 1.].into();
 
-    let mut xy = x + y;
-    let mut yz = z + y;
-    let mut xz = x + z;
-    let mut xyz = x + y + z;
-    xy.normalize();
-    yz.normalize();
-    xz.normalize();
-    xyz.normalize();
+    let xy = x + y;
+    let yz = z + y;
+    let xz = x + z;
+    let xyz = x + y + z;
+    let xy = xy.normalize();
+    let yz = yz.normalize();
+    let xz = xz.normalize();
+    let xyz = xyz.normalize();
 
     let ra = std::f32::consts::PI / 2.;
     let rsqrt2 = (0.5_f32).sqrt();
@@ -226,14 +226,14 @@ fn test_matrix() {
     let y = Vec3::from_array([0., 1., 0.]);
     let z = Vec3::from_array([0., 0., 1.]);
 
-    let mut xy = x + y;
-    let mut yz = z + y;
-    let mut xz = x + z;
-    let mut xyz = x + y + z;
-    xy.normalize();
-    yz.normalize();
-    xz.normalize();
-    xyz.normalize();
+    let xy = x + y;
+    let yz = z + y;
+    let xz = x + z;
+    let xyz = x + y + z;
+    let _xy = xy.normalize();
+    let _yz = yz.normalize();
+    let _xz = xz.normalize();
+    let xyz = xyz.normalize();
 
     let q = Quat::of_rijk(1., 0., 0., 0.);
     let mut m = Mat3::default();
@@ -286,13 +286,13 @@ fn test_matrix() {
     assert!(quat_eq(&q, &q2));
 
     q = Quat::of_rijk(1., 2., 3., 4.);
-    q.normalize();
+    q = q.normalize();
     q.set_rotation3(&mut m);
     let q2 = Quat::of_rotation3(&m);
     assert!(quat_eq(&q, &q2));
 
     q = Quat::of_rijk(4., 3., 2., 1.);
-    q.normalize();
+    q = q.normalize();
     q.set_rotation3(&mut m);
     let q2 = Quat::of_rotation3(&m);
     assert!(quat_eq(&q, &q2));
@@ -311,14 +311,14 @@ fn test_look_at() {
     let y = Vec3::from_array([0., 1., 0.]);
     let z = Vec3::from_array([0., 0., 1.]);
 
-    let mut xy = x + y;
-    let mut yz = z + y;
-    let mut xz = x + z;
-    let mut xyz = x + y + z;
-    xy.normalize();
-    yz.normalize();
-    xz.normalize();
-    xyz.normalize();
+    let xy = x + y;
+    let yz = z + y;
+    let xz = x + z;
+    let xyz = x + y + z;
+    let xy = xy.normalize();
+    let yz = yz.normalize();
+    let _xz = xz.normalize();
+    let _xyz = xyz.normalize();
 
     let q = Quat::look_at(&z, &y);
     let t = q.apply3(&z);


### PR DESCRIPTION
 Release 0.5.0 (2023-02-18)

- Added multiply_dyn to matrix

- Added serialize/deserialize of types

- Added float 'pi' method

- Added uniform distribution of vectors on a unit sphere

- Added quaternion weighted averaging

- Much addition of inline and must_use

- Moved to Rust 2021 edition

- Added 'into_array' method

- Fixed SqMatrix mulitplication by Self to be matrix multiplication

- Removed SqMatrix division by Self

- Improved library documentation and examples

- Added glsl module, which is not ready yet